### PR TITLE
Add keycloak deployment based on docker to CI #17

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -62,4 +62,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-death: 2
+          fetch-depth: 2

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -62,4 +62,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-deth: 2
+          fetch-death: 2

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -30,7 +30,8 @@ jobs:
   run-keycloak:
     name: keycloak
     runs-on: ubuntu-latest
-    container: quay.io/keycloak/keycloak:latest
+    container: 
+      image: quay.io/keycloak/keycloak:latest
       env:
         KEYCLOAK_USER: admin
         KEYCLOAK_PASSWORD: admin

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -11,9 +11,7 @@ jobs:
       matrix:
         node-version: [16.15.0]
         os: [ubuntu-latest, windows-latest]
-
     runs-on: ${{ matrix.os }}
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -28,3 +26,39 @@ jobs:
         run: npm run build
       - name: Run Tests
         run: npm test
+
+  run-keycloak:
+    name: keycloak
+    runs-on: ubuntu-latest
+    container: quay.io/keycloak/keycloak:latest
+      env:
+        KEYCLOAK_USER: admin
+        KEYCLOAK_PASSWORD: admin
+      ports:
+        #http
+        - 8080:8080
+        #https
+        - 8443:8443
+        #ajp
+        - 8009:8009
+        #management
+        - 9990:9990
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_DB: keycloak
+          POSTGRES_USER: keycloak
+          POSTGRES_PASSWORD: pass
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 8
+        ports:
+          - 5432:5432
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-deth: 2

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -31,7 +31,7 @@ jobs:
     name: keycloak
     runs-on: ubuntu-latest
     container: 
-      image: quay.io/keycloak/keycloak:latest
+      image: bitnami/keycloak:latest
       env:
         KEYCLOAK_USER: admin
         KEYCLOAK_PASSWORD: admin


### PR DESCRIPTION
I have added a keycloak seup based on the latest container image from quay.io to our CI pipeline.
Signed-off-by: Sarah Julia Kriesch <sarah.j.kriesch@fau.de>